### PR TITLE
Infinite Craft - Improve handling of storing recipe pairs

### DIFF
--- a/neal.fun/infinite_craft_combo_tracker/infinite_craft_combo_tracker.user.js
+++ b/neal.fun/infinite_craft_combo_tracker/infinite_craft_combo_tracker.user.js
@@ -47,10 +47,14 @@
         console.log(`crafted ${lhs} + ${rhs} -> ${result}`);
         const data = GM_getValue(GM_VALUE_KEY, {});
         if(!(result in data)) data[result] = [];
-        for(const [a, b] in data[result]) {
-            if(a === lhs && b === rhs) return;
+        const sortedLhsRhs = [lhs, rhs];
+        sortedLhsRhs.sort();
+        for(const existingPair of data[result]) {
+            if(sortedLhsRhs[0] === existingPair[0] && sortedLhsRhs[1] === existingPair[1]) return;
         }
-        data[result].push([lhs, rhs]);
+        const pair = [lhs, rhs];
+        pair.sort();
+        data[result].push(pair);
         GM_setValue(GM_VALUE_KEY, data);
     }
     function getCombos() {


### PR DESCRIPTION
As far as I am aware, the order in which you craft stuff has no bearing on the result. Feel free to tell me I'm wrong! Anyways, this commit changes the recipe book to sort the input pairs, and to filter out duplicates.