### PR TITLE
Fix visibility of "wrap text" and code block color in dark theme

### DIFF
--- a/cohost.org/view_source/view_source.user.js
+++ b/cohost.org/view_source/view_source.user.js
@@ -121,12 +121,11 @@ function handle_show_post_source_click(article, view_source_btn, post_id) {
             //
             create('div', {
                 parent: article,
-                classList: ['prose', 'px-3', 'amgg__viewsource__source-view-container'],
+                classList: ['co-prose', 'prose', 'px-3', 'amgg__viewsource__source-view-container'],
                 children: [
                     // "wrap text" checkbox
                     create('label', {
                         textContent: 'wrap text ',
-                        classList: ['text-notBlack'],
                         children: [create('input', {
                             type: 'checkbox',
                             checked: false,


### PR DESCRIPTION
Hi, the "wrap text" text was not visible while using the dark theme.
A less important side effect of the fix is the code block background color also changes based on the current theme or the "invert colors" per-post toggle. Tested on Firefox with Tampermonkey and Greasemonkey.

Before:
![2024-02-23_16:02:45](https://github.com/adrianmgg/userscripts/assets/54293288/b99d8846-7b7f-4e6a-b256-66a94a2e8284)

After:
![2024-02-23_16:03:45](https://github.com/adrianmgg/userscripts/assets/54293288/89fd11cd-439f-4ce9-b70e-fc47052f9e70)

Behavior on light theme stays the same:
![2024-02-23_16:11:11](https://github.com/adrianmgg/userscripts/assets/54293288/b92f16b6-a441-4c96-950b-b99ae2f45ba8)